### PR TITLE
fixes for onMove: stay & follow, more tests

### DIFF
--- a/test/append.js
+++ b/test/append.js
@@ -1,0 +1,60 @@
+
+var assert   = require('assert');
+var child    = require('child_process');
+var fs       = require('fs');
+var path     = require('path');
+
+var ts       = require('../index.js');
+var tmpDir   = path.resolve('test','tmp');
+var newLine  = 'The rain in spain falls mainly on the plain\n';
+
+var filePath = path.resolve(tmpDir, 'append');
+var childOpts = { env: {
+    TEST_FILE_PATH: filePath,
+    TEST_LOG_LINE: newLine,
+} };
+
+describe('tail-stream', function () {
+
+    context('file is appended', function () {
+
+        before(function (done) {
+            // create test/tmp, if not already
+            fs.mkdir(tmpDir, function (err) {
+                fs.writeFile(filePath, newLine, function (err) {
+                    assert.ifError(err);
+                    done();
+                });
+            });
+        });
+
+        it('detects two appends', function (done) {
+
+            dataCount = 0;
+
+            var tstream = ts.createReadStream(filePath, {
+                beginAt: 'end',
+            });
+
+            tstream.on('data', function(data) {
+                dataCount++;
+                assert.equal(data.toString(), newLine);
+                if (dataCount === 2) done();
+            });
+
+            tstream.on('error', function(err) {
+                assert.ifError(err);
+            });
+
+            // append in a separate process, so this one gets the watch event
+            var cp = child.fork('./test/helpers/fileAppend.js', childOpts);
+            cp.on('message', function (msg) {
+                // console.log(msg);
+                var cp2 = child.fork('./test/helpers/fileAppend.js', childOpts);
+                cp2.on('message', function (msg) {
+                    // console.log(msg);
+                });
+            });
+        });
+    });
+});

--- a/test/helpers/fileAppend.js
+++ b/test/helpers/fileAppend.js
@@ -1,12 +1,12 @@
-
 var assert  = require('assert');
 var fs      = require('fs');
-var path    = require('path');
 
-var filePath = path.resolve('test', 'tmp', 'append');
-var newLine  = 'The rain in spain falls mainly on the plain\n';
+var filePath = process.env.TEST_FILE_PATH;
+var newLine  = process.env.TEST_LOG_LINE ||
+	           'you forget to set TEST_LOG_LINE\n';
 
 fs.appendFile(filePath, newLine, function (err) {
     assert.ifError(err);
-    // console.log('fileAppend -> fs.appendFile: ' + filePath);
+
+    process.send('fileAppend -> fs.appendFile: ' + filePath);
 });

--- a/test/helpers/fileCreate.js
+++ b/test/helpers/fileCreate.js
@@ -1,12 +1,12 @@
-
 var assert  = require('assert');
 var fs      = require('fs');
 var path    = require('path');
 
-var filePath = path.resolve('test', 'tmp', 'new'); // cross platform happy
-var newLine  = 'The rain in spain falls mainly on the plain\n';
+var filePath = process.env.TEST_FILE_PATH;
+var newLine  = process.env.TEST_LOG_LINE ||
+	'you forget to set TEST_LOG_LINE\n';
 
 fs.writeFile(filePath, newLine, function (err) {
     assert.ifError(err);
-    // console.log('fileCreate -> fs.writeFile ' + filePath);
+    process.send('fileCreate -> fs.writeFile ' + filePath);
 });

--- a/test/helpers/fileRename.js
+++ b/test/helpers/fileRename.js
@@ -1,12 +1,11 @@
-
 var assert  = require('assert');
 var fs      = require('fs');
 var path    = require('path');
 
-var oldPath = path.resolve('test', 'tmp', 'old');
-var newPath = path.resolve('test', 'tmp', 'new');
+var oldPath = process.env.TEST_OLD_PATH || path.resolve('test', 'tmp', 'old');
+var newPath = process.env.TEST_NEW_PATH || path.resolve('test', 'tmp', 'new');
 
 fs.rename(oldPath, newPath, function (err) {
     assert.ifError(err);
-    // console.log('fileRename -> fs.rename: ' + oldPath + ' -> ' + newPath);
+    process.send('fileRename -> fs.rename: \n\t' + oldPath + ' -> \n\t' + newPath);
 });

--- a/test/helpers/fileTruncate.js
+++ b/test/helpers/fileTruncate.js
@@ -1,9 +1,8 @@
-
 var assert  = require('assert');
 var fs      = require('fs');
 var path    = require('path');
 
-var filePath = path.resolve('test', 'tmp', 'truncate');
+var filePath = process.env.TEST_FILE_PATH;
 
 fs.truncate(filePath, 0, function (err) {
 	if (err) {
@@ -11,5 +10,6 @@ fs.truncate(filePath, 0, function (err) {
 	 	console.error(err);
 	 	return;
 	}
-	// console.log('fileTruncate -> fs.truncate: ' + filePath);
+
+    process.send('fileTruncate -> fs.truncate: ' + filePath);
 });

--- a/test/index.js
+++ b/test/index.js
@@ -4,12 +4,14 @@ var child    = require('child_process');
 var fs       = require('fs');
 var path     = require('path');
 
-var testdir  = path.resolve('test','tmp');
+var ts       = require('../index.js');
+var tmpDir   = path.resolve('test','tmp');
 var newLine  = 'The rain in spain falls mainly on the plain\n';
 
+/*
 before(function (done) {
     // create test/tmp, if not already
-    fs.mkdir(testdir, function (err) {
+    fs.mkdir(tmpDir, function (err) {
         // assert.ifError(err);
         done();
     });
@@ -17,149 +19,27 @@ before(function (done) {
 
 after(function (done) {
     // clean up our tmp files
-    fs.readdir(testdir, function (err, files) {
+    fs.readdir(tmpDir, function (err, files) {
         if (err) console.error(err);
         if (files) {
             files.forEach(function (file) {
-                fs.unlinkSync(path.resolve('test','tmp', file));
-            });            
+                fs.unlinkSync(path.resolve(tmpDir, file));
+            });
         }
         done();
     });
 });
-
-describe('tail-stream', function () {
-
-    context('file is appended', function () {
-
-        var filePath = path.resolve('test', 'tmp', 'append');
-        before(function (done) {
-            fs.writeFile(filePath, newLine, function (err) {
-                assert.ifError(err);
-                done();
-            });
-        });
-
-        it('detects appends', function (done) {
-            
-            dataCount = 0;
-            var ts      = require('../index.js');
-            var tstream = ts.createReadStream(filePath, {
-                beginAt: 'end',
-            });
-
-            tstream.on('data', function(data) {
-                dataCount++;
-                assert.equal(data.toString(), newLine);
-                if (dataCount === 2) done();
-            });
-
-            tstream.on('error', function(err) {
-                assert.ifError(err);
-            });
-
-            // append in a separate process, so this one gets the watch event
-            child.fork('./test/helpers/fileAppend.js');
-
-            // if these are "too close" together, they can detect as a
-            // single append, causing the data equal test to fail.
-            setTimeout(function () {
-                child.fork('./test/helpers/fileAppend.js');
-            }, 10);
-        });
-    });
-
-    context('file is rotated', function () {
-        var oldPath = path.resolve('test', 'tmp', 'old');
-        var newPath = path.resolve('test', 'tmp', 'new');
-
-        before(function (done) {
-            fs.writeFile(oldPath, newLine, function (err) {
-                assert.ifError(err);
-                done();
-            });
-        });
-
-        it('detects rotation', function (done) {
-
-            var ts      = require('../index.js');
-            var tstream = ts.createReadStream(oldPath, {
-                beginAt: 'end',
-                onMove: 'follow',
-                endOnError: false
-            });
-
-            tstream.on('data', function(data) {
-                // console.log(data.toString());
-                assert.ok(!data);
-            });
-
-            tstream.on('move', function(before, after) {
-                assert.equal(oldPath, before);
-                if (!/\//.test(after)) {
-                    after = path.resolve('test', 'tmp', after);
-                }
-                assert.equal(newPath, after);
-                done();
-            });
-
-            tstream.on('error', function(err) {
-                assert.ifError(err);
-            });
-
-            // move in a separate process, so this one gets the watch event
-            child.fork('./test/helpers/fileRename.js');
-        });
-    });
-
-    context('file is truncated', function () {
-
-        var truncPath = path.resolve('test', 'tmp', 'truncate');
-        before(function (done) {
-            fs.writeFile(truncPath, newLine, function (err) {
-                assert.ifError(err);
-                // console.log('before truncate, wrote 1 line');
-                done();
-            });
-        });
-
-        it('truncation is detected', function (done) {
-
-            var ts      = require('../index.js');
-            var tstream = ts.createReadStream(truncPath, {
-                detectTruncate: true,
-                endOnError: false,
-            });
-
-            tstream.on('data', function(data) {
-                // console.log(data.toString());
-                assert.equal(data.toString(), newLine);
-            });
-
-            tstream.on('truncate', function(newsize, oldsize) {
-                assert.equal(44, oldsize);
-                assert.equal(0, newsize);
-                done();
-            });
-
-            tstream.on('error', function(err) {
-                assert.ifError(err);
-            });
-
-            // do in a separate process, so this one gets the watch event
-            child.fork('./test/helpers/fileTruncate.js');
-        });
-    });
-});
+*/
 
 describe.skip('tail-stream all events', function () {
     it('has all events', function (done) {
 
-        var filePath = path.resolve('test', 'tmp', 'changeMe');
+        var filePath = path.resolve(tmpDir, 'changeMe');
+        var childOpts = { env: { TEST_FILE_PATH: filePath } };
+
         fs.writeFile(filePath, newLine, function (err) {
             assert.ifError(err);
 
-            var ts      = require('../index.js');
             var tstream = ts.createReadStream(filePath, {
                 onMove: 'follow',
                 detectTruncate: true,
@@ -177,24 +57,25 @@ describe.skip('tail-stream all events', function () {
             });
 
             tstream.on('eof', function() {
-                console.log("Reached end of file.");
+                console.log('Reached end of file.');
             });
 
             tstream.on('truncate', function(newsize, oldsize) {
-                console.log("File truncated from: " + oldsize + " to " + newsize + " bytes");
+                console.log('File truncated from: ' + oldsize + ' to ' +
+                    newsize + ' bytes');
                 done();
             });
 
             tstream.on('end', function() {
-                console.log("Ended");
+                console.log('Ended');
             });
 
             tstream.on('error', function(err) {
-                console.log("Error: " + err); 
+                console.log('Error: ' + err);
             });
 
             // in a separate process, so this one gets the watch event
-            // child.fork('./test/helpers/fileTruncate.js');
+            // child.fork('./test/helpers/file_____.js', childOpts);
         });
     });
 });

--- a/test/rotate.js
+++ b/test/rotate.js
@@ -1,0 +1,223 @@
+
+var assert   = require('assert');
+var child    = require('child_process');
+var fs       = require('fs');
+var path     = require('path');
+
+var ts       = require('../index.js');
+var tmpDir   = path.resolve('test','tmp');
+var newLine  = 'The rain in spain falls mainly on the plain\n';
+
+describe('tail-stream', function () {
+
+    context('file is rotated', function () {
+
+        it('detects rotation', function (done) {
+
+            var oldPath = path.resolve(tmpDir, 'rotate');
+            var childOpts = { env: {
+                    TEST_OLD_PATH: oldPath,
+                    TEST_NEW_PATH: path.resolve(tmpDir, 'rotate.1'),
+                } };
+
+            fs.writeFile(oldPath, newLine, function (err) {
+                assert.ifError(err);
+
+                var childDone = false;
+
+                var tstream = ts.createReadStream(oldPath, {
+                    beginAt: 'end',
+                    onMove: 'follow',
+                    endOnError: false,
+                });
+
+                tstream.on('error', function(err) {
+                    console.error(err);
+                    assert.ifError(err);
+                });
+
+                tstream.on('data', function(data) {
+                    assert.ok(!data);
+                });
+
+                tstream.on('move', function(before, after) {
+
+                    assert.equal(oldPath, before);
+
+                    if (after !== null && !/\//.test(after)) {
+                        // fully qualify the name
+                        after = path.resolve(tmpDir, after);
+                    }
+                    assert.equal(childOpts.env.TEST_NEW_PATH, after);
+                    done();
+                });
+
+                // move in a separate process, so this one gets the watch event
+                var cp = child.fork('./test/helpers/fileRename.js', childOpts);
+                cp.on('message', function (msg) {
+                    // example of waiting for child to finish
+                    // console.log(msg);
+                });
+            });
+        });
+
+        it('detects rotation concurrently', function (done) {
+
+            var oldPath = path.resolve(tmpDir, 'rotate2');
+            var childOpts = { env: {
+                    TEST_OLD_PATH: oldPath,
+                    TEST_NEW_PATH: path.resolve(tmpDir, 'rotate2.1'),
+                } };
+            var childDone = false;
+
+            fs.writeFile(oldPath, newLine, function (err) {
+                assert.ifError(err);
+
+                var tstream = ts.createReadStream(oldPath, {
+                    beginAt: 'end',
+                    onMove: 'follow',    // default
+                    endOnError: false,
+                });
+
+                tstream.on('error', function(err) {
+                    console.error(err);
+                    assert.ifError(err);
+                });
+
+                tstream.on('data', function(data) {
+                    assert.ok(!data);
+                });
+
+                tstream.on('move', function(before, after) {
+
+                    assert.equal(oldPath, before);
+
+                    if (after !== null && !/\//.test(after)) {
+                        // fully qualify the name
+                        after = path.resolve(tmpDir, after);
+                    }
+                    assert.equal(childOpts.env.TEST_NEW_PATH, after);
+                    done();
+                });
+
+                // rename in a separate process, so this one gets the watch event
+                child.fork('./test/helpers/fileRename.js', childOpts);
+            });
+        });
+    });
+
+    context('onMove', function () {
+
+        it('follow, emits append to new file after rotation', function (done) {
+
+            var rolledPath = path.resolve(tmpDir, 'rotateFollow');
+            var childOpts = { env: {
+                TEST_FILE_PATH: rolledPath,
+                TEST_OLD_PATH: rolledPath,
+                TEST_NEW_PATH: path.resolve(tmpDir, 'rotateFollow.1'),
+                } };
+
+            fs.writeFile(rolledPath, newLine, function (err) {
+                assert.ifError(err);
+
+                var tstream = ts.createReadStream(rolledPath, {
+                    beginAt: 'end',
+                    onMove: 'follow',
+                    endOnError: false,
+                });
+
+                tstream.on('error', function(err) {
+                    console.error(err);
+                    assert.ifError(err);
+                });
+
+                tstream.on('data', function(data) {
+                    // console.log(data.toString());
+                    assert.equal(newLine, data);
+                    done();
+                });
+
+                tstream.on('move', function(before, after) {
+
+                    assert.equal(rolledPath, before);
+
+                    if (after !== null && !/\//.test(after)) {
+                        // fully qualify the name
+                        after = path.resolve(tmpDir, after);
+                    }
+                    assert.equal(childOpts.env.TEST_NEW_PATH, after);
+
+                    child.fork('./test/helpers/fileAppend.js', { env: {
+                        TEST_FILE_PATH: childOpts.env.TEST_NEW_PATH,
+                        TEST_LOG_LINE: newLine,
+                        } }
+                    );
+                });
+
+                // move in a separate process, so this one gets the watch event
+                child.fork('./test/helpers/fileRename.js', childOpts);
+            });
+        });
+
+        it('stay, emits append to old file after rotation', function (done) {
+
+            var rolledPath = path.resolve(tmpDir, 'rotateStay');
+            var childOpts = { env: {
+                TEST_OLD_PATH: rolledPath,
+                TEST_NEW_PATH: path.resolve(tmpDir, 'rotateStay.1'),
+                } };
+
+            fs.writeFile(rolledPath, newLine, function (err) {
+                assert.ifError(err);
+
+                var tstream = ts.createReadStream(rolledPath, {
+                    beginAt: 'end',
+                    onMove: 'stay',
+                    endOnError: false,
+                    useWatch: true,
+                });
+
+                tstream.on('error', function(err) {
+                    console.error(err);
+                    assert.ifError(err);
+                });
+
+                tstream.on('eof', function() {
+                    // console.log('Reached end of file.');
+                });
+
+                tstream.on('data', function(data) {
+                    // console.log(data.toString());
+                    assert.equal(newLine, data);
+                    done();
+                });
+
+                tstream.on('replace', function() {
+                    // console.log('the file was replaced!');
+                });
+
+                tstream.on('move', function(before, after) {
+                    assert.equal(rolledPath, before);
+
+                    if (after !== null && !/\//.test(after)) {
+                        // fully qualify the name
+                        after = path.resolve(tmpDir, after);
+                    }
+                    assert.equal(childOpts.env.TEST_NEW_PATH, after);
+
+                    var cp = child.fork('./test/helpers/fileAppend.js', { env: {
+                        TEST_FILE_PATH: childOpts.env.TEST_OLD_PATH,
+                        TEST_LOG_LINE: newLine,
+                        } }
+                    );
+                    cp.on('message', function (msg) {
+                        // console.log(msg);
+                    });
+                });
+
+                // move in a separate process, so this one gets the watch event
+                child.fork('./test/helpers/fileRename.js', childOpts);
+            });
+        });
+    });
+});

--- a/test/truncate.js
+++ b/test/truncate.js
@@ -1,0 +1,116 @@
+
+var assert   = require('assert');
+var child    = require('child_process');
+var fs       = require('fs');
+var path     = require('path');
+
+var ts       = require('../index.js');
+var tmpDir   = path.resolve('test','tmp');
+var newLine  = 'The rain in spain falls mainly on the plain\n';
+
+describe('tail-stream', function () {
+
+    context('file is truncated', function () {
+
+        before(function (done) {
+            fs.mkdir(tmpDir, function (err) {
+                // console.log('before truncate, wrote 1 line');
+                done();
+            });
+        });
+
+        it('truncation is detected', function (done) {
+
+            var truncPath = path.resolve(tmpDir, 'truncate');
+
+            fs.writeFile(truncPath, newLine, function (err) {
+                assert.ifError(err);
+
+                var tstream = ts.createReadStream(truncPath, {
+                    beginAt: 0,
+                    detectTruncate: true,
+                    endOnError: false,
+                });
+
+                tstream.on('error', function(err) {
+                    assert.ifError(err);
+                });
+
+                tstream.on('data', function(data) {
+                    // console.log(data.toString());
+                    assert.equal(data.toString(), newLine);
+                });
+
+                tstream.on('truncate', function(newsize, oldsize) {
+                    assert.equal(44, oldsize);
+                    assert.equal(0, newsize);
+                    done();
+                });
+
+                // do in a separate process, so this one gets the watch event
+                var cp = child.fork('./test/helpers/fileTruncate.js', { env: {
+                    TEST_FILE_PATH: truncPath,
+                } });
+                cp.on('message', function (msg) {
+                    // console.log(msg);
+                });
+            });
+        });
+
+        it('write after truncation is read', function (done) {
+
+            var truncPath = path.resolve(tmpDir, 'truncate');
+            var childDone = false;
+
+            fs.writeFile(truncPath, newLine, function (err) {
+                assert.ifError(err);
+
+                var tryDone = function () {
+                    if (childDone) return done();
+                    setTimeout(function () {
+                        // console.log('not yet');
+                        tryDone();
+                    }, 10);
+                };
+
+                var tstream = ts.createReadStream(truncPath, {
+                    beginAt: 0,
+                    detectTruncate: true,
+                    endOnError: false,
+                });
+
+                tstream.on('error', function(err) {
+                    assert.ifError(err);
+                });
+
+                tstream.on('data', function(data) {
+                    // console.log(data.toString());
+                    assert.equal(data.toString(), newLine);
+                    tryDone();
+                });
+
+                tstream.on('truncate', function(newsize, oldsize) {
+                    assert.equal(44, oldsize);
+                    assert.equal(0, newsize);
+
+                    child.fork('./test/helpers/fileAppend.js', { env: {
+                        TEST_FILE_PATH: truncPath,
+                        TEST_LOG_LINE: newLine,
+                    } })
+                    .on('message', function (msg) {
+                        // console.log(msg);
+                        childDone = true;
+                    });
+                });
+
+                // do in a separate process, so this one gets the watch event
+                child.fork('./test/helpers/fileTruncate.js', { env: {
+                    TEST_FILE_PATH: truncPath,
+                } })
+                .on('message', function (msg) {
+                    // console.log(msg);
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
- when /proc fails, use event info in getCurrentPath
- separate tests into files
- additional rotate tests, onMove:stay & follow
- always use fs.watch
  - avoid try/catch if ! -e /proc
    added read-after-truncate test

```
$ mocha

  tail-stream
    file is appended
      ✓ detects two appends (91ms)

  tail-stream all events
    - has all events

  tail-stream
    file is rotated
      ✓ detects rotation (44ms)
      ✓ detects rotation concurrently (45ms)
    onMove
      ✓ follow, emits append to new file after rotation (91ms)
      ✓ stay, emits append to old file after rotation (1147ms)

  tail-stream
    file is truncated
      ✓ truncation is detected (52ms)
      ✓ write after truncation is read 


  7 passing (1s)
  1 pending
```
