### PR TITLE
Added checks to avoid crashes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,9 @@ function TailStream(filepath, opts) {
         // we will switch to fs.watchFile
         // until a file re-appears at this.path
         if(this.opts.useWatch) {
-            this.watcher.close();
+            if(this.watcher && this.watcher.close) {
+                this.watcher.close();
+            }
             this.watcher = null;
         }
         fs.close(this.fd);
@@ -163,13 +165,17 @@ function TailStream(filepath, opts) {
     }.bind(this);
 
     this.end = function(errCode) {
-        if(errCode != 'EBADF') {
+        if(!this.fd) {
+            return false;
+        }
+        if(errCode != 'EBADF') { 
             fs.close(this.fd);
+            this.fd = null;
         }
         this.push(null);
         if(this.watcher === true) {
             fs.unwatchFile(this.path, this.watchFileCallback);
-        } else {
+        } else if(this.watcher && this.watcher.close) {
             this.watcher.close();
         }
     };
@@ -238,7 +244,9 @@ function TailStream(filepath, opts) {
             }
             this.firstRead = false;
         }
-
+        if(!this.fd) {
+            return false;
+        }
         fs.read(this.fd, this.buffer, 0, this.buffer.length, this.bytesRead, function(err, bytesRead, buffer) {
             if(err) {
                 if(this.opts.endOnError) {
@@ -273,5 +281,4 @@ module.exports = ts = {
     createReadStream: function(path, options) {
         return new TailStream(path, options);
     }
-
 };

--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@ function TailStream(filepath, opts) {
             this.watcher = null;
         }
         fs.close(this.fd);
+        this.fd = null;
         this.waitingForReappear = true;
         this.waitForMoreData(true);
     };


### PR DESCRIPTION
Added checks to avoid crashes when calling end() during the "read-up" fase (as opposed to the active tailing fase), or when calling it more than once.

The real-world case would be ending the (tail-)stream if the data read matches a defined end condition, f.ex. when using this module and some "glue" to sequentially read a collection of log files [and pass the data through byline or similar], and ending the stream once you get to your desired [potentially future] date/time.