### PR TITLE
Preventing EBADF errors from async close operation.

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,6 +181,7 @@ function TailStream(filepath, opts) {
             fs.close(this.fd, function() {
                 this.fd = null;
             });
+			this.fd = null;
         }
         this.push(null);
         if(this.watcher === true) {


### PR DESCRIPTION
Calling _tail-stream_.end() inside a downstream stream handler (f.ex. piping tail-stream to a Transform-stream implementing a filter) causes the file to be closed after _read_ has been called, but before _readCont_. This causes an exception as the file pointer is NULL'ed in the callback of _fs.close(this.fd..._